### PR TITLE
ignore vote transactions from cost model

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1166,7 +1166,11 @@ impl BankingStage {
                 .filter_map(|(tx, tx_index)| {
                     // put transaction into retry queue if it wouldn't fit
                     // into current bank
-                    if cost_tracker_readonly
+                    let is_vote = &msgs.packets[tx_index].meta.is_simple_vote_tx;
+
+                    // excluding vote TX from cost_model, for now
+                    if !is_vote &&
+                        cost_tracker_readonly
                         .would_transaction_fit(&tx, demote_program_write_locks, cost_tracker_stats)
                         .is_err()
                     {


### PR DESCRIPTION
#### Problem
cost model may cap number of votes being packed into a block, therefore delays votes.

#### Summary of Changes
cost model ignores vote transactions, for now

Fixes #
